### PR TITLE
Fix ASPP ONNX export by pre-building ResizingND in build()

### DIFF
--- a/medicai/layers/conv.py
+++ b/medicai/layers/conv.py
@@ -550,6 +550,18 @@ class AtrousSpatialPyramidPooling(layers.Layer):
         projection.build(input_shape[:-1] + (projection_input_channels,))
         self.projection = projection
         self.spatial_dims = spatial_dims
+
+        pool_target = tuple(input_shape[i] for i in range(1, 1 + spatial_dims))
+        self._pool_resize = ResizingND(
+            target_shape=pool_target,
+            interpolation="bilinear" if spatial_dims == 2 else "trilinear",
+            name="pool_resize",
+        )
+        pool_resize_input = (
+            input_shape[:1] + (1,) * spatial_dims + (self.num_channels,)
+        )
+        self._pool_resize.build(pool_resize_input)
+
         self.built = True
 
     def call(self, inputs):
@@ -558,12 +570,7 @@ class AtrousSpatialPyramidPooling(layers.Layer):
             temp = ops.cast(channel(inputs), inputs.dtype)
             result.append(temp)
 
-        input_shape = ops.shape(inputs)
-        target_size = tuple(input_shape[i] for i in range(1, 1 + self.spatial_dims))
-
-        result[-1] = ResizingND(
-            target_size, interpolation="bilinear" if self.spatial_dims == 2 else "trilinear"
-        )(result[-1])
+        result[-1] = self._pool_resize(result[-1])
 
         result = ops.concatenate(result, axis=-1)
         return self.projection(result)

--- a/test/models/test_models.py
+++ b/test/models/test_models.py
@@ -4,6 +4,7 @@ import tensorflow as tf
 from medicai.models import (
     UNETR,
     ConvNeXtV2Atto,
+    DeepLabV3Plus,
     DenseNet121,
     EfficientNetB0,
     SegFormer,
@@ -210,6 +211,34 @@ def test_vit():
     x3d = tf.random.normal((batch_size, D, H, W, C))
     y3d = vit3d(x3d)
     assert y3d.shape == (batch_size, num_classes)
+
+
+def test_deeplabv3plus():
+    num_classes = 3
+
+    # test for 3D
+    input_shape = (64, 64, 64, 1)
+    model = DeepLabV3Plus(
+        input_shape=input_shape,
+        num_classes=num_classes,
+        encoder_name="efficientnet_v2_s",
+        encoder_depth=3,
+    )
+    dummy_input = tf.random.normal((1, 64, 64, 64, 1))
+    output = model(dummy_input)
+    assert output.shape == (1, 64, 64, 64, num_classes)
+
+    # test for 2D
+    input_shape = (64, 64, 3)
+    model = DeepLabV3Plus(
+        input_shape=input_shape,
+        num_classes=num_classes,
+        encoder_name="efficientnet_v2_s",
+        encoder_depth=3,
+    )
+    dummy_input = tf.random.normal((1, 64, 64, 3))
+    output = model(dummy_input)
+    assert output.shape == (1, 64, 64, num_classes)
 
 
 def test_segformer():


### PR DESCRIPTION
Fixes #89

`AtrousSpatialPyramidPooling.call()` creates a new `ResizingND` on every forward pass, which breaks ONNX export. The target spatial dimensions are statically known at `build()` time, so this moves the `ResizingND` instantiation from `call()` to `build()`.

Also adds a `test_deeplabv3plus` test (2D + 3D) to match the other segmentation model tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DeepLabV3Plus model now available with support for both 2D and 3D configurations

* **Tests**
  * Added test coverage for DeepLabV3Plus across multiple dimensional configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->