### PR TITLE
Modularize Sliding Window Inference

### DIFF
--- a/docs/guides/utility.md
+++ b/docs/guides/utility.md
@@ -2,18 +2,21 @@
 
 Utility classes and functions exported by `medicai.utils`.
 
-## GradCAM
-
-```{eval-rst}
-.. autoclass:: medicai.utils.GradCAM
-   :members: compute_heatmap
-```
-
 ## Sliding Window Inference
 
 ```{eval-rst}
 .. autoclass:: medicai.utils.SlidingWindowInference
 .. autofunction:: medicai.utils.sliding_window_inference
+.. autofunction:: medicai.utils.extract_patches
+.. autofunction:: medicai.utils.merge_patches
+.. autofunction:: medicai.utils.predict_patches
+```
+
+## GradCAM
+
+```{eval-rst}
+.. autoclass:: medicai.utils.GradCAM
+   :members: compute_heatmap
 ```
 
 ## Image Utilities

--- a/medicai/utils/__init__.py
+++ b/medicai/utils/__init__.py
@@ -3,7 +3,13 @@ from medicai.utils.constant import keras_constants
 from medicai.utils.describe_mixin import DescribeMixin
 from medicai.utils.general import camel_to_snake
 from medicai.utils.image import resize_volumes
-from medicai.utils.inference import SlidingWindowInference, sliding_window_inference
+from medicai.utils.inference import (
+    SlidingWindowInference,
+    extract_patches,
+    merge_patches,
+    predict_patches,
+    sliding_window_inference,
+)
 from medicai.utils.loss_utils import soft_skeletonize
 from medicai.utils.model_utils import (
     get_act_layer,

--- a/medicai/utils/cam.py
+++ b/medicai/utils/cam.py
@@ -358,8 +358,8 @@ class BaseCAM(ABC):
 
 class GradCAM(BaseCAM):
     """
-    Gradient-weighted Class Activation Mapping (Grad-CAM). Grad-CAM generates coarse 
-    localization heatmaps highlighting the spatial regions that most strongly influence 
+    Gradient-weighted Class Activation Mapping (Grad-CAM). Grad-CAM generates coarse
+    localization heatmaps highlighting the spatial regions that most strongly influence
     a model’s prediction for a target class. The method works by:
 
     1. Computing gradients of the target prediction with respect to feature maps
@@ -389,8 +389,8 @@ class GradCAM(BaseCAM):
         resize_heatmap=True,
     ):
         """
-        Computes the Grad-CAM heatmap for a target class. The heatmap represents spatial 
-        importance scores indicating which regions of the input most strongly contributed 
+        Computes the Grad-CAM heatmap for a target class. The heatmap represents spatial
+        importance scores indicating which regions of the input most strongly contributed
         to the target prediction. Computation steps:
 
         1. Compute gradients of the target score with respect to feature maps.
@@ -404,7 +404,7 @@ class GradCAM(BaseCAM):
             input_tensor: The input tensor (image or volume). Supported shapes ``(B, H, W, C)``
                 for 2D and ``(B, D, H, W, C)`` for 3D.
             target_class_index (int or None, optional): Index of the target class for heatmap generation.
-                If ``None``, the predicted class may be selected automatically depending on 
+                If ``None``, the predicted class may be selected automatically depending on
                 the parent implementation.
             mask_type: Type of mask to apply during segmentation target calculation
 
@@ -493,7 +493,7 @@ class GradCAM(BaseCAM):
         Returns:
             The final normalized heatmap as a NumPy array
             ``(Batch, H, W, 1)`` or ``(Batch, [D,] H, W, 1)``.
-        
+
         References:
             - Grad-CAM: Visual Explanations from Deep Networks via Gradient-based Localization.
               `arXiv:1610.02391 <https://arxiv.org/abs/1610.02391>`_

--- a/medicai/utils/image.py
+++ b/medicai/utils/image.py
@@ -3,8 +3,8 @@ from keras import ops
 
 def resize_volumes(volumes, depth, height, width, method="trilinear", align_corners=False):
     """
-    Resizes 5D volumetric tensors using either trilinear interpolation or nearest-neighbor sampling. This function 
-    provides a backend-agnostic implementation of ``3D`` resizing for tensors shaped as 
+    Resizes 5D volumetric tensors using either trilinear interpolation or nearest-neighbor sampling. This function
+    provides a backend-agnostic implementation of ``3D`` resizing for tensors shaped as
     ``(batch, depth, height, width, channels)``. It supports two interpolation strategies:
 
     1. **Trilinear interpolation**:
@@ -43,7 +43,7 @@ def resize_volumes(volumes, depth, height, width, method="trilinear", align_corn
                 - Generally produces smoother and more stable resizing behavior.
 
     Examples:
-        .. code-block:: python 
+        .. code-block:: python
 
             import torch
             from medicai.utils import resize_volumes
@@ -51,14 +51,15 @@ def resize_volumes(volumes, depth, height, width, method="trilinear", align_corn
             x = torch.rand(1, 96, 96, 96, 3)
             output = resize_volumes(
                 x,
-                depth=128, 
-                height=128, 
+                depth=128,
+                height=128,
                 width=128,
-                method='trilinear', 
+                method='trilinear',
                 align_corners=False
             )
             print(output.shape) # (1, 128, 128, 128, 3)
     """
+
     def trilinear_resize(volumes, depth, height, width, align_corners):
         original_dtype = volumes.dtype
         volumes = ops.cast(volumes, "float32")

--- a/medicai/utils/inference.py
+++ b/medicai/utils/inference.py
@@ -15,6 +15,12 @@ from .swi_utils import (
 )
 
 
+_NUMPY_PADDING_MODE_ALIASES = {
+    "replicate": "edge",
+    "circular": "wrap",
+}
+
+
 class SlidingWindowInference:
     """
     Sliding Window Inference for large-volume or high-resolution inputs. This class
@@ -191,9 +197,10 @@ def extract_patches(
         pad_size.append([half, diff - half])
     pad_size = [[0, 0]] + pad_size + [[0, 0]]
 
+    normalized_padding_mode = _normalize_padding_mode(padding_mode)
     if any(value for pair in pad_size for value in pair):
-        pad_kwargs = {"mode": padding_mode.lower()}
-        if padding_mode.lower() == "constant":
+        pad_kwargs = {"mode": normalized_padding_mode}
+        if normalized_padding_mode == "constant":
             pad_kwargs["constant_values"] = cval
         inputs = np.pad(inputs, pad_size, **pad_kwargs)
 
@@ -201,14 +208,19 @@ def extract_patches(
     slices = dense_patch_slices(padded_image_size, roi_size, scan_interval)
 
     valid_patch_size = get_valid_patch_size(padded_image_size, roi_size)
-    if valid_patch_size == roi_size and roi_weight_map is not None:
-        importance_map = roi_weight_map
+    if roi_weight_map is not None:
+        importance_map = _normalize_roi_weight_map(
+            roi_weight_map=roi_weight_map,
+            patch_size=valid_patch_size,
+            dtype=inputs.dtype,
+            num_spatial_dims=num_spatial_dims,
+        )
     else:
         importance_map = compute_importance_map(
             valid_patch_size, mode=mode, sigma_scale=sigma_scale, dtype=inputs.dtype
         )
-        if len(importance_map.shape) == num_spatial_dims:
-            importance_map = np.expand_dims(np.expand_dims(importance_map, -1), 0)
+    if len(importance_map.shape) == num_spatial_dims:
+        importance_map = np.expand_dims(np.expand_dims(importance_map, -1), 0)
 
     info = {
         "batch_size": batch_size,
@@ -221,6 +233,46 @@ def extract_patches(
         "importance_map": importance_map,
     }
     return inputs, info
+
+
+def _normalize_padding_mode(padding_mode: str) -> str:
+    """Translate documented padding aliases to NumPy-compatible modes."""
+    normalized_mode = padding_mode.lower()
+    return _NUMPY_PADDING_MODE_ALIASES.get(normalized_mode, normalized_mode)
+
+
+def _normalize_roi_weight_map(
+    roi_weight_map,
+    patch_size: Sequence[int],
+    dtype,
+    num_spatial_dims: int,
+) -> np.ndarray:
+    """Normalize a caller-supplied ROI weight map to ``(1, *roi_size, 1)``."""
+    importance_map = np.asarray(roi_weight_map, dtype=dtype)
+
+    if importance_map.ndim == 0:
+        return np.full((1, *patch_size, 1), importance_map, dtype=dtype)
+
+    if importance_map.ndim == num_spatial_dims:
+        if tuple(importance_map.shape) != tuple(patch_size):
+            raise ValueError(
+                "roi_weight_map must match the effective ROI spatial size when "
+                "provided without batch/channel dimensions."
+            )
+        return importance_map[None, ..., None]
+
+    if importance_map.ndim != num_spatial_dims + 2:
+        raise ValueError(
+            "roi_weight_map must be a scalar, a spatial-only tensor shaped like roi_size, "
+            "or a tensor shaped (1, *roi_size, 1)."
+        )
+
+    expected_shape = (1, *patch_size, 1)
+    if tuple(importance_map.shape) != expected_shape:
+        raise ValueError(
+            f"roi_weight_map must have shape {expected_shape}, got {tuple(importance_map.shape)}."
+        )
+    return importance_map
 
 
 def _resize_importance_map(importance_map: np.ndarray, target_shape: Sequence[int]) -> np.ndarray:

--- a/medicai/utils/inference.py
+++ b/medicai/utils/inference.py
@@ -14,7 +14,6 @@ from .swi_utils import (
     get_valid_patch_size,
 )
 
-
 _NUMPY_PADDING_MODE_ALIASES = {
     "replicate": "edge",
     "circular": "wrap",
@@ -37,6 +36,22 @@ class SlidingWindowInference:
     2. Each patch is processed independently by the model.
     3. Predictions are aggregated back into the full spatial volume.
     4. Overlapping regions are blended using either constant or Gaussian weighting.
+
+    Note:
+        Current support is intentionally narrow:
+
+        - single-input tensors only
+        - single-output tensors only
+        - channel-last 2D inputs shaped ``(B, H, W, C)``
+        - channel-last 3D inputs shaped ``(B, D, H, W, C)``
+        - segmentation-style outputs whose spatial shape matches ``roi_size``
+
+        Not yet supported:
+
+        - classification-style outputs such as ``(B, num_classes)``
+        - multi-input models
+        - multi-output models
+        - outputs whose spatial shape differs from ``roi_size``
 
     Args:
         model: Callable that takes a patch of input and returns predictions.
@@ -84,9 +99,9 @@ class SlidingWindowInference:
             print(output.shape) # (1, 128, 128, 128, 3)
 
     Returns:
-        np.ndarray: The output tensor with the same batch size and
-            spatial dimensions as the input, and the number of channels
-            equal to ``num_classes``.
+        ``np.ndarray``: The output tensor with the same batch size and
+        spatial dimensions as the input, and the number of channels
+        equal to ``num_classes``.
     """
 
     def __init__(
@@ -165,9 +180,30 @@ def extract_patches(
         cval: Constant fill value used with ``padding_mode="constant"``.
         roi_weight_map: Optional precomputed ROI importance map.
 
+    Example:
+        .. code-block:: python
+
+            import tensorflow as tf
+            from medicai.utils import extract_patches
+
+            x = tf.random.uniform((1, 128, 128, 128, 1))
+            padded_inputs, info = extract_patches(
+                inputs=x,
+                roi_size=(96, 96, 96),
+                overlap=0.25,
+            )
+            print(padded_inputs.shape)
+            print(len(info["slices"]))
+
     Returns:
         A tuple ``(padded_inputs, info)`` where ``info`` contains the metadata
         required to run patch prediction and merge the overlapping outputs.
+
+    Raises:
+        ValueError: If ``inputs`` does not have shape
+            ``(batch_size, *spatial_dims, channels)``.
+        ValueError: If any overlap value is outside the interval ``[0, 1)``.
+        ValueError: If ``roi_weight_map`` has an unsupported shape.
     """
     inputs = np.array(inputs) if not isinstance(inputs, np.ndarray) else inputs
     if inputs.ndim < 3:
@@ -302,9 +338,43 @@ def predict_patches(
         model: Object exposing ``predict(x, verbose=0)``.
         sw_batch_size: Number of spatial windows evaluated per call.
 
+    Example:
+        .. code-block:: python
+
+            import tensorflow as tf
+            from medicai.models import UNet
+            from medicai.utils import extract_patches, predict_patches
+
+            model = UNet(
+                encoder_name="efficientnet_b1",
+                input_shape=(96, 96, 96, 1),
+                num_classes=2,
+            )
+            x = tf.random.uniform((1, 128, 128, 128, 1))
+            padded_inputs, info = extract_patches(
+                inputs=x,
+                roi_size=(96, 96, 96),
+                overlap=0.25,
+            )
+
+            patch_generator = predict_patches(
+                padded_inputs=padded_inputs,
+                info=info,
+                model=model,
+                sw_batch_size=2,
+            )
+            pred_batch, batch_slices, importance_map = next(patch_generator)
+            print(pred_batch.shape)
+            print(len(batch_slices))
+
     Yields:
         Tuples of ``(pred_batch, batch_slices, importance_map_resized)`` for
         each patch batch.
+
+    Raises:
+        ValueError: If ``sw_batch_size`` is not a positive integer.
+        ValueError: If the model output spatial shape does not match
+            ``info["roi_size"]``.
     """
     if sw_batch_size <= 0:
         raise ValueError(f"sw_batch_size must be a positive integer, got {sw_batch_size}.")
@@ -365,9 +435,43 @@ def merge_patches(
         num_classes: Number of output channels. If ``None``, inferred from the
             first yielded prediction batch.
 
+    Example:
+        .. code-block:: python
+
+            import tensorflow as tf
+            from medicai.models import UNet
+            from medicai.utils import extract_patches, merge_patches, predict_patches
+
+            model = UNet(
+                encoder_name="efficientnet_b1",
+                input_shape=(96, 96, 96, 1),
+                num_classes=2,
+            )
+            x = tf.random.uniform((1, 128, 128, 128, 1))
+            padded_inputs, info = extract_patches(
+                inputs=x,
+                roi_size=(96, 96, 96),
+                overlap=0.25,
+            )
+            patch_generator = predict_patches(
+                padded_inputs=padded_inputs,
+                info=info,
+                model=model,
+                sw_batch_size=2,
+            )
+            output = merge_patches(
+                patch_generator=patch_generator,
+                info=info,
+                num_classes=2,
+            )
+            print(output.shape)
+
     Returns:
         Reconstructed output tensor with shape
         ``(batch_size, *original_spatial_dims, num_classes)``.
+
+    Raises:
+        ValueError: If ``patch_generator`` yields no predictions.
     """
     batch_size = info["batch_size"]
     padded_image_size = info["padded_image_size"]

--- a/medicai/utils/inference.py
+++ b/medicai/utils/inference.py
@@ -306,11 +306,15 @@ def predict_patches(
         Tuples of ``(pred_batch, batch_slices, importance_map_resized)`` for
         each patch batch.
     """
+    if sw_batch_size <= 0:
+        raise ValueError(f"sw_batch_size must be a positive integer, got {sw_batch_size}.")
+
     slices = info["slices"]
     batch_size = info["batch_size"]
     importance_map = info["importance_map"]
     importance_map_resized = None
     has_multiple_patch_batches = len(slices) > sw_batch_size
+    roi_size = tuple(info["roi_size"])
 
     progress_desc = f"Window positions {len(slices)} | input batch {batch_size}"
     for start in tqdm(range(0, len(slices), sw_batch_size), desc=progress_desc):
@@ -333,6 +337,13 @@ def predict_patches(
 
         pred = model.predict(patches, verbose=0)
         pred = pred[:actual_patch_batch]
+
+        if tuple(pred.shape[1:-1]) != roi_size:
+            raise ValueError(
+                "sliding_window_inference requires the model output spatial shape "
+                f"to match roi_size. Got output shape {tuple(pred.shape[1:-1])} "
+                f"and roi_size {roi_size}."
+            )
 
         if importance_map_resized is None:
             importance_map_resized = _resize_importance_map(importance_map, pred.shape[1:-1])

--- a/medicai/utils/inference.py
+++ b/medicai/utils/inference.py
@@ -113,12 +113,12 @@ class SlidingWindowInference:
         self.cval = cval
         self.roi_weight_map = roi_weight_map
 
-    def __call__(self, inputs):
+    def __call__(self, x):
         """
         Call method to perform sliding window inference.
 
         Args:
-            inputs (np.ndarray): Input tensor with shape
+            x (np.ndarray): Input tensor with shape
                 (batch_size, *spatial_dims, channels).
 
         Returns:
@@ -127,7 +127,7 @@ class SlidingWindowInference:
                 equal to ``num_classes``.
         """
         return sliding_window_inference(
-            inputs=inputs,
+            x=x,
             model=self.model,
             num_classes=self.num_classes,
             roi_size=self.roi_size,
@@ -389,7 +389,7 @@ def merge_patches(
 
 
 def sliding_window_inference(
-    inputs,
+    x,
     model,
     num_classes: Optional[int],
     roi_size: Sequence[int],
@@ -404,7 +404,7 @@ def sliding_window_inference(
     """Run sliding-window inference over large 2D or 3D inputs.
 
     Args:
-        inputs: Input tensor with shape ``(batch_size, *spatial_dims, channels)``.
+        x: Input tensor with shape ``(batch_size, *spatial_dims, channels)``.
         model: Object exposing ``predict(x, verbose=0)``.
         num_classes: Number of output channels. If ``None``, inferred from the
             first prediction batch.
@@ -424,7 +424,7 @@ def sliding_window_inference(
         ``(batch_size, *original_spatial_dims, num_classes)``.
     """
     padded_inputs, info = extract_patches(
-        inputs=inputs,
+        inputs=x,
         roi_size=roi_size,
         overlap=overlap,
         mode=mode,

--- a/medicai/utils/inference.py
+++ b/medicai/utils/inference.py
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence, Union
+from typing import Generator, Optional, Sequence, Union
 
 import numpy as np
 from scipy.ndimage import zoom
@@ -17,9 +17,9 @@ from .swi_utils import (
 
 class SlidingWindowInference:
     """
-    Sliding Window Inference for large-volume or high-resolution inputs. This class 
-    performs patch-based inference by dividing the input tensor into overlapping regions 
-    of interest (ROIs), running a model on each patch, and merging the outputs using a 
+    Sliding Window Inference for large-volume or high-resolution inputs. This class
+    performs patch-based inference by dividing the input tensor into overlapping regions
+    of interest (ROIs), running a model on each patch, and merging the outputs using a
     specified blending strategy.
 
     It is commonly used in medical imaging and volumetric segmentation tasks
@@ -67,7 +67,7 @@ class SlidingWindowInference:
             )
             swi = SlidingWindowInference(
                 model,
-                num_classes=3, 
+                num_classes=3,
                 roi_size=(96, 96, 96),
                 sw_batch_size=2,
                 overlap=0.25,
@@ -82,6 +82,7 @@ class SlidingWindowInference:
             spatial dimensions as the input, and the number of channels
             equal to ``num_classes``.
     """
+
     def __init__(
         self,
         model,
@@ -134,6 +135,207 @@ class SlidingWindowInference:
         )
 
 
+def extract_patches(
+    inputs: np.ndarray,
+    roi_size: Sequence[int],
+    overlap: Union[Sequence[float], float] = 0.25,
+    mode: str = "constant",
+    sigma_scale: Union[Sequence[float], float] = 0.125,
+    padding_mode: str = "constant",
+    cval: float = 0.0,
+    roi_weight_map: Optional[np.ndarray] = None,
+) -> tuple[np.ndarray, dict]:
+    """Prepare padded inputs and patch metadata for sliding-window inference.
+
+    Args:
+        inputs: Input tensor with shape ``(batch_size, *spatial_dims, channels)``.
+        roi_size: Spatial window size for inference.
+        overlap: Overlap ratio between windows.
+        mode: Importance-map blending mode. Supported values are ``"constant"``
+            and ``"gaussian"``.
+        sigma_scale: Gaussian blending coefficient used when ``mode="gaussian"``.
+        padding_mode: NumPy padding mode applied when an input dimension is
+            smaller than the requested ROI size.
+        cval: Constant fill value used with ``padding_mode="constant"``.
+        roi_weight_map: Optional precomputed ROI importance map.
+
+    Returns:
+        A tuple ``(padded_inputs, info)`` where ``info`` contains the metadata
+        required to run patch prediction and merge the overlapping outputs.
+    """
+    inputs = np.array(inputs) if not isinstance(inputs, np.ndarray) else inputs
+    if inputs.ndim < 3:
+        raise ValueError(
+            "Input tensor must have shape (batch_size, *spatial_dims, channels), "
+            f"got rank {inputs.ndim}."
+        )
+
+    num_spatial_dims = len(inputs.shape) - 2
+    overlap = ensure_tuple_rep(overlap, num_spatial_dims)
+    sigma_scale = ensure_tuple_rep(sigma_scale, num_spatial_dims)
+
+    for value in overlap:
+        if value < 0 or value >= 1:
+            raise ValueError(f"Overlap must be >= 0 and < 1, got {overlap}.")
+
+    batch_size, *original_image_size, _ = inputs.shape
+    roi_size = fall_back_tuple(roi_size, original_image_size)
+    padded_image_size = tuple(
+        max(original_image_size[index], roi_size[index]) for index in range(num_spatial_dims)
+    )
+
+    pad_size = []
+    for index in range(num_spatial_dims):
+        diff = max(roi_size[index] - original_image_size[index], 0)
+        half = diff // 2
+        pad_size.append([half, diff - half])
+    pad_size = [[0, 0]] + pad_size + [[0, 0]]
+
+    if any(value for pair in pad_size for value in pair):
+        pad_kwargs = {"mode": padding_mode.lower()}
+        if padding_mode.lower() == "constant":
+            pad_kwargs["constant_values"] = cval
+        inputs = np.pad(inputs, pad_size, **pad_kwargs)
+
+    scan_interval = get_scan_interval(padded_image_size, roi_size, num_spatial_dims, overlap)
+    slices = dense_patch_slices(padded_image_size, roi_size, scan_interval)
+
+    valid_patch_size = get_valid_patch_size(padded_image_size, roi_size)
+    if valid_patch_size == roi_size and roi_weight_map is not None:
+        importance_map = roi_weight_map
+    else:
+        importance_map = compute_importance_map(
+            valid_patch_size, mode=mode, sigma_scale=sigma_scale, dtype=inputs.dtype
+        )
+        if len(importance_map.shape) == num_spatial_dims:
+            importance_map = np.expand_dims(np.expand_dims(importance_map, -1), 0)
+
+    info = {
+        "batch_size": batch_size,
+        "num_spatial_dims": num_spatial_dims,
+        "original_image_size": tuple(original_image_size),
+        "padded_image_size": padded_image_size,
+        "pad_size": pad_size,
+        "roi_size": tuple(roi_size),
+        "slices": slices,
+        "importance_map": importance_map,
+    }
+    return inputs, info
+
+
+def _resize_importance_map(importance_map: np.ndarray, target_shape: Sequence[int]) -> np.ndarray:
+    """Resize an importance map to match the prediction spatial shape."""
+    if tuple(importance_map.shape[1:-1]) == tuple(target_shape):
+        return importance_map
+
+    scale_factors = [1.0]
+    scale_factors.extend(
+        target_shape[index] / importance_map.shape[index + 1] for index in range(len(target_shape))
+    )
+    scale_factors.append(1.0)
+    return zoom(importance_map, tuple(scale_factors), order=0)
+
+
+def predict_patches(
+    padded_inputs: np.ndarray,
+    info: dict,
+    model,
+    sw_batch_size: int,
+) -> Generator[tuple[np.ndarray, list[tuple[slice, ...]], np.ndarray], None, None]:
+    """Run inference over patch batches and yield predictions lazily.
+
+    Args:
+        padded_inputs: Padded input tensor returned by :func:`extract_patches`.
+        info: Metadata dictionary returned by :func:`extract_patches`.
+        model: Object exposing ``predict(x, verbose=0)``.
+        sw_batch_size: Number of spatial windows evaluated per call.
+
+    Yields:
+        Tuples of ``(pred_batch, batch_slices, importance_map_resized)`` for
+        each patch batch.
+    """
+    slices = info["slices"]
+    batch_size = info["batch_size"]
+    importance_map = info["importance_map"]
+    importance_map_resized = None
+
+    for start in tqdm(range(0, len(slices), sw_batch_size), desc=f"Total patch {len(slices)}"):
+        batch_slices = slices[start : start + sw_batch_size]
+        patch_list = []
+        for slice_idx in batch_slices:
+            full_slice = (slice(None),) + slice_idx + (slice(None),)
+            patch_list.append(padded_inputs[full_slice])
+        patches = np.concatenate(patch_list, axis=0)
+
+        # Pad the final batch so XLA-compiling backends can keep a static batch size.
+        actual_patch_batch = patches.shape[0]
+        target_patch_batch = sw_batch_size * batch_size
+        if actual_patch_batch < target_patch_batch:
+            batch_pad_size = ((0, target_patch_batch - actual_patch_batch),) + ((0, 0),) * (
+                patches.ndim - 1
+            )
+            patches = np.pad(patches, batch_pad_size, mode="constant", constant_values=0)
+
+        pred = model.predict(patches, verbose=0)
+        pred = pred[:actual_patch_batch]
+
+        if importance_map_resized is None:
+            importance_map_resized = _resize_importance_map(importance_map, pred.shape[1:-1])
+
+        yield pred, batch_slices, importance_map_resized
+
+
+def merge_patches(
+    patch_generator: Generator[tuple[np.ndarray, list[tuple[slice, ...]], np.ndarray], None, None],
+    info: dict,
+    num_classes: Optional[int] = None,
+) -> np.ndarray:
+    """Merge overlapping patch predictions into a full-resolution output.
+
+    Args:
+        patch_generator: Patch prediction generator produced by
+            :func:`predict_patches`.
+        info: Metadata dictionary returned by :func:`extract_patches`.
+        num_classes: Number of output channels. If ``None``, inferred from the
+            first yielded prediction batch.
+
+    Returns:
+        Reconstructed output tensor with shape
+        ``(batch_size, *original_spatial_dims, num_classes)``.
+    """
+    batch_size = info["batch_size"]
+    padded_image_size = info["padded_image_size"]
+    original_image_size = info["original_image_size"]
+    pad_size = info["pad_size"]
+
+    output_image = None
+    count_map = None
+
+    for pred_batch, batch_slices, importance_map_resized in patch_generator:
+        if output_image is None:
+            resolved_num_classes = num_classes or pred_batch.shape[-1]
+            output_shape = [batch_size] + list(padded_image_size) + [resolved_num_classes]
+            output_image = np.zeros(output_shape, dtype=np.float32)
+            count_map = np.zeros([1] + list(padded_image_size) + [1], dtype=np.float32)
+
+        for index, slice_idx in enumerate(batch_slices):
+            output_slice = (slice(None),) + slice_idx + (slice(None),)
+            start = index * batch_size
+            stop = start + batch_size
+            output_image[output_slice] += pred_batch[start:stop] * importance_map_resized
+            count_map[output_slice] += importance_map_resized
+
+    if output_image is None or count_map is None:
+        raise ValueError("Patch generator yielded no predictions.")
+
+    np.divide(output_image, count_map, out=output_image, where=count_map != 0)
+
+    if any(value for pair in pad_size for value in pair):
+        output_image = crop_output(output_image, pad_size, original_image_size)
+
+    return output_image
+
+
 def sliding_window_inference(
     inputs,
     model,
@@ -147,98 +349,46 @@ def sliding_window_inference(
     cval: float = 0.0,
     roi_weight_map=None,
 ):
-    # Ensure overlap and sigma_scale are sequences
-    inputs = np.array(inputs) if not isinstance(inputs, np.ndarray) else inputs
-    num_spatial_dims = len(inputs.shape) - 2  # Exclude batch and channel dimensions
-    overlap = ensure_tuple_rep(overlap, num_spatial_dims)
-    sigma_scale = ensure_tuple_rep(sigma_scale, num_spatial_dims)
+    """Run sliding-window inference over large 2D or 3D inputs.
 
-    # Validate overlap values
-    for o in overlap:
-        if o < 0 or o >= 1:
-            raise ValueError(f"Overlap must be >= 0 and < 1, got {overlap}.")
+    Args:
+        inputs: Input tensor with shape ``(batch_size, *spatial_dims, channels)``.
+        model: Object exposing ``predict(x, verbose=0)``.
+        num_classes: Number of output channels. If ``None``, inferred from the
+            first prediction batch.
+        roi_size: Spatial window size for inference.
+        sw_batch_size: Number of spatial windows evaluated per predict call.
+        overlap: Overlap ratio between windows.
+        mode: Importance-map blending mode. Supported values are ``"constant"``
+            and ``"gaussian"``.
+        sigma_scale: Gaussian blending coefficient used when ``mode="gaussian"``.
+        padding_mode: NumPy padding mode applied when an input dimension is
+            smaller than the requested ROI size.
+        cval: Constant fill value used with ``padding_mode="constant"``.
+        roi_weight_map: Optional precomputed ROI importance map.
 
-    # Determine image spatial size and batch size
-    batch_size, *image_size_, _ = inputs.shape  # Unpack for channels-last format
-    roi_size = fall_back_tuple(roi_size, image_size_)
-
-    # Pad input if necessary
-    image_size = tuple(max(image_size_[i], roi_size[i]) for i in range(num_spatial_dims))
-    pad_size = []
-    for k in range(num_spatial_dims):
-        diff = max(roi_size[k] - image_size_[k], 0)
-        half = diff // 2
-        pad_size.append([half, diff - half])
-    pad_size = [[0, 0]] + pad_size + [[0, 0]]  # Add padding for batch and channel dimensions
-
-    if any(p for pair in pad_size for p in pair):
-        inputs = np.pad(inputs, pad_size, mode=padding_mode.lower(), constant_values=cval)
-
-    # Compute scan intervals
-    scan_interval = get_scan_interval(image_size, roi_size, num_spatial_dims, overlap)
-    slices = dense_patch_slices(image_size, roi_size, scan_interval)
-
-    # Create importance map
-    valid_patch_size = get_valid_patch_size(image_size, roi_size)
-    if valid_patch_size == roi_size and roi_weight_map is not None:
-        importance_map = roi_weight_map
-    else:
-        importance_map = compute_importance_map(
-            valid_patch_size, mode=mode, sigma_scale=sigma_scale, dtype=inputs.dtype
-        )
-        if len(importance_map.shape) == num_spatial_dims:
-            importance_map = np.expand_dims(
-                np.expand_dims(importance_map, -1), 0
-            )  # Add batch and channel dims
-
-    # Initialize output and count maps as NumPy arrays
-    num_classes = num_classes or model.output_shape[-1]
-    output_shape = [batch_size] + list(image_size) + [num_classes]
-    output_image = np.zeros(output_shape, dtype="float32")
-    count_map = np.zeros([1] + list(image_size) + [1], dtype="float32")
-
-    # Apply sliding window inference in batches
-    for i in tqdm(range(0, len(slices), sw_batch_size), desc=f"Total patch {len(slices)}"):
-        batch_slices = slices[i : i + sw_batch_size]
-        patch_list = []
-        for slice_idx in batch_slices:
-            full_slice = (slice(None),) + slice_idx + (slice(None),)
-            patch = inputs[full_slice]
-            patch_list.append(patch)
-        patches = np.concatenate(patch_list, axis=0)  # Stack patches along batch dimension
-
-        # GitHub: https://github.com/keras-team/keras/issues/21167
-        # padded if needed - its useful for XLA complilation to support tpu or jax backend.
-        bs_actual = patches.shape[0]
-        bs_target = sw_batch_size
-        if bs_actual < bs_target:
-            batch_pad_size = ((0, bs_target - bs_actual), (0, 0), (0, 0), (0, 0), (0, 0))
-            patches = np.pad(patches, batch_pad_size, mode="constant", constant_values=0)
-
-        # Predict on the batch of patches
-        pred = model.predict(patches, verbose=0)
-        pred = pred[:bs_actual]
-
-        # Resize importance map if necessary
-        if pred.shape[1:-1] != roi_size:  # Exclude batch and channel dimensions
-            _, d, h, w, _ = importance_map.shape
-            target_shape = pred.shape[1:-1]
-            scale_factors = (1, target_shape[0] / d, target_shape[1] / h, target_shape[2] / w, 1)
-            importance_map_resized = zoom(importance_map, scale_factors, order=0)
-        else:
-            importance_map_resized = importance_map
-
-        # Accumulate predictions using NumPy
-        for j, slice_idx in enumerate(batch_slices):
-            output_slice = (slice(None),) + slice_idx + (slice(None),)
-            output_image[output_slice] += pred[j] * importance_map_resized
-            count_map[output_slice] += importance_map_resized
-
-    # Normalize output by count map
-    output_image /= count_map
-
-    # Remove padding if necessary
-    if any(p for pair in pad_size for p in pair):
-        output_image = crop_output(output_image, pad_size, image_size_)
-
-    return output_image
+    Returns:
+        Reconstructed output tensor with shape
+        ``(batch_size, *original_spatial_dims, num_classes)``.
+    """
+    padded_inputs, info = extract_patches(
+        inputs=inputs,
+        roi_size=roi_size,
+        overlap=overlap,
+        mode=mode,
+        sigma_scale=sigma_scale,
+        padding_mode=padding_mode,
+        cval=cval,
+        roi_weight_map=roi_weight_map,
+    )
+    patch_generator = predict_patches(
+        padded_inputs=padded_inputs,
+        info=info,
+        model=model,
+        sw_batch_size=sw_batch_size,
+    )
+    return merge_patches(
+        patch_generator=patch_generator,
+        info=info,
+        num_classes=num_classes,
+    )

--- a/medicai/utils/inference.py
+++ b/medicai/utils/inference.py
@@ -310,8 +310,10 @@ def predict_patches(
     batch_size = info["batch_size"]
     importance_map = info["importance_map"]
     importance_map_resized = None
+    has_multiple_patch_batches = len(slices) > sw_batch_size
 
-    for start in tqdm(range(0, len(slices), sw_batch_size), desc=f"Total patch {len(slices)}"):
+    progress_desc = f"Window positions {len(slices)} | input batch {batch_size}"
+    for start in tqdm(range(0, len(slices), sw_batch_size), desc=progress_desc):
         batch_slices = slices[start : start + sw_batch_size]
         patch_list = []
         for slice_idx in batch_slices:
@@ -319,10 +321,11 @@ def predict_patches(
             patch_list.append(padded_inputs[full_slice])
         patches = np.concatenate(patch_list, axis=0)
 
-        # Pad the final batch so XLA-compiling backends can keep a static batch size.
+        # Pad only when multiple predict calls are needed so XLA-compiling
+        # backends can keep a static batch size across calls.
         actual_patch_batch = patches.shape[0]
         target_patch_batch = sw_batch_size * batch_size
-        if actual_patch_batch < target_patch_batch:
+        if has_multiple_patch_batches and actual_patch_batch < target_patch_batch:
             batch_pad_size = ((0, target_patch_batch - actual_patch_batch),) + ((0, 0),) * (
                 patches.ndim - 1
             )

--- a/medicai/utils/inference.py
+++ b/medicai/utils/inference.py
@@ -248,12 +248,12 @@ def extract_patches(
         importance_map = _normalize_roi_weight_map(
             roi_weight_map=roi_weight_map,
             patch_size=valid_patch_size,
-            dtype=inputs.dtype,
+            dtype=np.float32,
             num_spatial_dims=num_spatial_dims,
         )
     else:
         importance_map = compute_importance_map(
-            valid_patch_size, mode=mode, sigma_scale=sigma_scale, dtype=inputs.dtype
+            valid_patch_size, mode=mode, sigma_scale=sigma_scale, dtype=np.float32
         )
     if len(importance_map.shape) == num_spatial_dims:
         importance_map = np.expand_dims(np.expand_dims(importance_map, -1), 0)

--- a/medicai/utils/loss_utils.py
+++ b/medicai/utils/loss_utils.py
@@ -67,7 +67,7 @@ def soft_skeletonize(inputs, iters):
             Values are typically expected to be in the range ``[0, 1]``.
 
         iters (int):
-            Number of iterative erosion steps used to construct the skeleton. Larger values produce more complete skeletons for larger objects 
+            Number of iterative erosion steps used to construct the skeleton. Larger values produce more complete skeletons for larger objects
             but increase computational cost.
 
     Returns:

--- a/medicai/utils/model_utils.py
+++ b/medicai/utils/model_utils.py
@@ -335,7 +335,7 @@ def get_dropout_layer(spatial_dims, layer_type, **kwargs):
     than individual elements, which is often more effective for convolutional
     neural networks.
 
-    
+
     Args:
         spatial_dims (int):
             Number of spatial dimensions. Supported values are:

--- a/test/utils/test_inference.py
+++ b/test/utils/test_inference.py
@@ -18,6 +18,18 @@ class DummySegmentationModel:
         return np.concatenate(channels, axis=-1).astype(np.float32)
 
 
+class RecordingSegmentationModel(DummySegmentationModel):
+    """Test model that records the batch dimension seen by predict()."""
+
+    def __init__(self, num_classes: int):
+        super().__init__(num_classes=num_classes)
+        self.seen_batch_sizes = []
+
+    def predict(self, patches: np.ndarray, verbose: int = 0) -> np.ndarray:
+        self.seen_batch_sizes.append(int(patches.shape[0]))
+        return super().predict(patches, verbose=verbose)
+
+
 @pytest.mark.unit
 def test_sliding_window_inference_matches_full_prediction_for_large_2d_input():
     model = DummySegmentationModel(num_classes=3)
@@ -72,6 +84,48 @@ def test_sliding_window_inference_handles_multi_item_batches():
     expected = model.predict(inputs, verbose=0)
     assert output.shape == (2, 18, 22, 2)
     np.testing.assert_allclose(output, expected, atol=1e-6)
+
+
+@pytest.mark.unit
+def test_sliding_window_inference_preserves_sample_identity_across_five_volumes():
+    model = DummySegmentationModel(num_classes=2)
+    base = np.zeros((5, 16, 18, 20, 1), dtype=np.float32)
+    for sample_index in range(base.shape[0]):
+        base[sample_index, ..., 0] = float(sample_index + 1)
+
+    output = sliding_window_inference(
+        x=base,
+        model=model,
+        num_classes=2,
+        roi_size=(10, 12, 14),
+        sw_batch_size=2,
+        overlap=0.25,
+    )
+
+    expected = model.predict(base, verbose=0)
+    assert output.shape == (5, 16, 18, 20, 2)
+    np.testing.assert_allclose(output, expected, atol=1e-6)
+    for sample_index in range(base.shape[0]):
+        np.testing.assert_allclose(output[sample_index, ..., 0], sample_index + 1, atol=1e-6)
+        np.testing.assert_allclose(output[sample_index, ..., 1], sample_index + 2, atol=1e-6)
+
+
+@pytest.mark.unit
+def test_sliding_window_inference_skips_padding_for_single_patch_batch():
+    model = RecordingSegmentationModel(num_classes=2)
+    x = np.random.randn(1, 8, 10, 12, 1).astype(np.float32)
+
+    output = sliding_window_inference(
+        x=x,
+        model=model,
+        num_classes=2,
+        roi_size=(12, 14, 16),
+        sw_batch_size=8,
+        overlap=0.25,
+    )
+
+    assert output.shape == (1, 8, 10, 12, 2)
+    assert model.seen_batch_sizes == [1]
 
 
 @pytest.mark.unit

--- a/test/utils/test_inference.py
+++ b/test/utils/test_inference.py
@@ -1,0 +1,91 @@
+import numpy as np
+import pytest
+
+from medicai.utils.inference import SlidingWindowInference, sliding_window_inference
+
+
+class DummySegmentationModel:
+    """Simple spatially preserving test model for sliding-window inference."""
+
+    def __init__(self, num_classes: int):
+        self.output_shape = (None, None, None, num_classes)
+        self.num_classes = num_classes
+
+    def predict(self, patches: np.ndarray, verbose: int = 0) -> np.ndarray:
+        channels = []
+        for class_index in range(self.num_classes):
+            channels.append(patches[..., :1] + float(class_index))
+        return np.concatenate(channels, axis=-1).astype(np.float32)
+
+
+@pytest.mark.unit
+def test_sliding_window_inference_matches_full_prediction_for_large_2d_input():
+    model = DummySegmentationModel(num_classes=3)
+    inputs = np.random.randn(1, 32, 48, 1).astype(np.float32)
+
+    output = sliding_window_inference(
+        inputs=inputs,
+        model=model,
+        num_classes=3,
+        roi_size=(16, 20),
+        sw_batch_size=3,
+        overlap=0.25,
+    )
+
+    expected = model.predict(inputs, verbose=0)
+    np.testing.assert_allclose(output, expected, atol=1e-6)
+
+
+@pytest.mark.unit
+def test_sliding_window_inference_pads_and_crops_3d_input_smaller_than_roi():
+    model = DummySegmentationModel(num_classes=2)
+    inputs = np.random.randn(1, 8, 10, 12, 1).astype(np.float32)
+
+    output = sliding_window_inference(
+        inputs=inputs,
+        model=model,
+        num_classes=2,
+        roi_size=(12, 14, 16),
+        sw_batch_size=2,
+        overlap=0.5,
+    )
+
+    expected = model.predict(inputs, verbose=0)
+    assert output.shape == (1, 8, 10, 12, 2)
+    np.testing.assert_allclose(output, expected, atol=1e-6)
+
+
+@pytest.mark.unit
+def test_sliding_window_inference_handles_multi_item_batches():
+    model = DummySegmentationModel(num_classes=2)
+    inputs = np.random.randn(2, 18, 22, 1).astype(np.float32)
+
+    output = sliding_window_inference(
+        inputs=inputs,
+        model=model,
+        num_classes=None,
+        roi_size=(9, 11),
+        sw_batch_size=4,
+        overlap=0.5,
+    )
+
+    expected = model.predict(inputs, verbose=0)
+    assert output.shape == (2, 18, 22, 2)
+    np.testing.assert_allclose(output, expected, atol=1e-6)
+
+
+@pytest.mark.unit
+def test_sliding_window_inference_class_wrapper_preserves_behavior():
+    model = DummySegmentationModel(num_classes=2)
+    inputs = np.random.randn(1, 20, 24, 1).astype(np.float32)
+    inferencer = SlidingWindowInference(
+        model=model,
+        num_classes=2,
+        roi_size=(10, 12),
+        sw_batch_size=2,
+        overlap=0.25,
+    )
+
+    output = inferencer(inputs)
+    expected = model.predict(inputs, verbose=0)
+    np.testing.assert_allclose(output, expected, atol=1e-6)

--- a/test/utils/test_inference.py
+++ b/test/utils/test_inference.py
@@ -171,6 +171,26 @@ def test_sliding_window_inference_requires_output_shape_to_match_roi_size():
 
 
 @pytest.mark.unit
+def test_sliding_window_inference_handles_integer_inputs_with_gaussian_blending():
+    model = DummySegmentationModel(num_classes=2)
+    x = np.random.randint(0, 10, size=(1, 16, 20, 1), dtype=np.uint8)
+
+    output = sliding_window_inference(
+        x=x,
+        model=model,
+        num_classes=2,
+        roi_size=(8, 10),
+        sw_batch_size=2,
+        overlap=0.25,
+        mode="gaussian",
+    )
+
+    expected = model.predict(x.astype(np.float32), verbose=0)
+    assert output.shape == (1, 16, 20, 2)
+    np.testing.assert_allclose(output, expected, atol=1e-5)
+
+
+@pytest.mark.unit
 def test_sliding_window_inference_class_wrapper_preserves_behavior():
     model = DummySegmentationModel(num_classes=2)
     inputs = np.random.randn(1, 20, 24, 1).astype(np.float32)

--- a/test/utils/test_inference.py
+++ b/test/utils/test_inference.py
@@ -89,3 +89,61 @@ def test_sliding_window_inference_class_wrapper_preserves_behavior():
     output = inferencer(inputs)
     expected = model.predict(inputs, verbose=0)
     np.testing.assert_allclose(output, expected, atol=1e-6)
+
+
+@pytest.mark.unit
+def test_sliding_window_inference_accepts_scalar_roi_weight_map():
+    model = DummySegmentationModel(num_classes=2)
+    inputs = np.random.randn(1, 16, 20, 1).astype(np.float32)
+
+    output = sliding_window_inference(
+        inputs=inputs,
+        model=model,
+        num_classes=2,
+        roi_size=(8, 10),
+        sw_batch_size=2,
+        overlap=0.25,
+        roi_weight_map=0.8,
+    )
+
+    expected = model.predict(inputs, verbose=0)
+    np.testing.assert_allclose(output, expected, atol=1e-6)
+
+
+@pytest.mark.unit
+def test_sliding_window_inference_accepts_spatial_only_roi_weight_map():
+    model = DummySegmentationModel(num_classes=2)
+    inputs = np.random.randn(1, 16, 20, 1).astype(np.float32)
+    roi_weight_map = np.ones((8, 10), dtype=np.float32)
+
+    output = sliding_window_inference(
+        inputs=inputs,
+        model=model,
+        num_classes=2,
+        roi_size=(8, 10),
+        sw_batch_size=2,
+        overlap=0.25,
+        roi_weight_map=roi_weight_map,
+    )
+
+    expected = model.predict(inputs, verbose=0)
+    np.testing.assert_allclose(output, expected, atol=1e-6)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("padding_mode", ["replicate", "circular"])
+def test_sliding_window_inference_supports_documented_padding_aliases(padding_mode):
+    model = DummySegmentationModel(num_classes=2)
+    inputs = np.random.randn(1, 6, 7, 1).astype(np.float32)
+
+    output = sliding_window_inference(
+        inputs=inputs,
+        model=model,
+        num_classes=2,
+        roi_size=(10, 11),
+        sw_batch_size=1,
+        overlap=0.25,
+        padding_mode=padding_mode,
+    )
+
+    assert output.shape == (1, 6, 7, 2)

--- a/test/utils/test_inference.py
+++ b/test/utils/test_inference.py
@@ -30,6 +30,14 @@ class RecordingSegmentationModel(DummySegmentationModel):
         return super().predict(patches, verbose=verbose)
 
 
+class DownsamplingSegmentationModel(DummySegmentationModel):
+    """Test model that changes spatial size to trigger ROI/output validation."""
+
+    def predict(self, patches: np.ndarray, verbose: int = 0) -> np.ndarray:
+        downsampled = patches[:, ::2, ::2, ...]
+        return super().predict(downsampled, verbose=verbose)
+
+
 @pytest.mark.unit
 def test_sliding_window_inference_matches_full_prediction_for_large_2d_input():
     model = DummySegmentationModel(num_classes=3)
@@ -126,6 +134,38 @@ def test_sliding_window_inference_skips_padding_for_single_patch_batch():
 
     assert output.shape == (1, 8, 10, 12, 2)
     assert model.seen_batch_sizes == [1]
+
+
+@pytest.mark.unit
+def test_sliding_window_inference_requires_positive_sw_batch_size():
+    model = DummySegmentationModel(num_classes=2)
+    x = np.random.randn(1, 8, 10, 1).astype(np.float32)
+
+    with pytest.raises(ValueError, match="sw_batch_size must be a positive integer"):
+        sliding_window_inference(
+            x=x,
+            model=model,
+            num_classes=2,
+            roi_size=(8, 10),
+            sw_batch_size=0,
+            overlap=0.25,
+        )
+
+
+@pytest.mark.unit
+def test_sliding_window_inference_requires_output_shape_to_match_roi_size():
+    model = DownsamplingSegmentationModel(num_classes=2)
+    x = np.random.randn(1, 16, 20, 1).astype(np.float32)
+
+    with pytest.raises(ValueError, match="requires the model output spatial shape to match roi_size"):
+        sliding_window_inference(
+            x=x,
+            model=model,
+            num_classes=2,
+            roi_size=(8, 10),
+            sw_batch_size=2,
+            overlap=0.25,
+        )
 
 
 @pytest.mark.unit

--- a/test/utils/test_inference.py
+++ b/test/utils/test_inference.py
@@ -24,7 +24,7 @@ def test_sliding_window_inference_matches_full_prediction_for_large_2d_input():
     inputs = np.random.randn(1, 32, 48, 1).astype(np.float32)
 
     output = sliding_window_inference(
-        inputs=inputs,
+        x=inputs,
         model=model,
         num_classes=3,
         roi_size=(16, 20),
@@ -42,7 +42,7 @@ def test_sliding_window_inference_pads_and_crops_3d_input_smaller_than_roi():
     inputs = np.random.randn(1, 8, 10, 12, 1).astype(np.float32)
 
     output = sliding_window_inference(
-        inputs=inputs,
+        x=inputs,
         model=model,
         num_classes=2,
         roi_size=(12, 14, 16),
@@ -61,7 +61,7 @@ def test_sliding_window_inference_handles_multi_item_batches():
     inputs = np.random.randn(2, 18, 22, 1).astype(np.float32)
 
     output = sliding_window_inference(
-        inputs=inputs,
+        x=inputs,
         model=model,
         num_classes=None,
         roi_size=(9, 11),
@@ -97,7 +97,7 @@ def test_sliding_window_inference_accepts_scalar_roi_weight_map():
     inputs = np.random.randn(1, 16, 20, 1).astype(np.float32)
 
     output = sliding_window_inference(
-        inputs=inputs,
+        x=inputs,
         model=model,
         num_classes=2,
         roi_size=(8, 10),
@@ -117,7 +117,7 @@ def test_sliding_window_inference_accepts_spatial_only_roi_weight_map():
     roi_weight_map = np.ones((8, 10), dtype=np.float32)
 
     output = sliding_window_inference(
-        inputs=inputs,
+        x=inputs,
         model=model,
         num_classes=2,
         roi_size=(8, 10),
@@ -137,7 +137,7 @@ def test_sliding_window_inference_supports_documented_padding_aliases(padding_mo
     inputs = np.random.randn(1, 6, 7, 1).astype(np.float32)
 
     output = sliding_window_inference(
-        inputs=inputs,
+        x=inputs,
         model=model,
         num_classes=2,
         roi_size=(10, 11),

--- a/test/utils/test_inference.py
+++ b/test/utils/test_inference.py
@@ -157,7 +157,9 @@ def test_sliding_window_inference_requires_output_shape_to_match_roi_size():
     model = DownsamplingSegmentationModel(num_classes=2)
     x = np.random.randn(1, 16, 20, 1).astype(np.float32)
 
-    with pytest.raises(ValueError, match="requires the model output spatial shape to match roi_size"):
+    with pytest.raises(
+        ValueError, match="requires the model output spatial shape to match roi_size"
+    ):
         sliding_window_inference(
             x=x,
             model=model,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the public utility API by re-exporting additional patch-based inference helpers for reuse (`extract_patches`, `merge_patches`, `predict_patches`).
  * Improved sliding-window inference with a staged patch pipeline for more reliable batched/padded inference on large inputs.

* **Bug Fixes**
  * Strengthened ROI weight-map normalization and handling of documented padding-mode aliases (for more consistent results).
  * More robust patch merging to better match direct full-input prediction.

* **Tests**
  * Added unit tests covering 2D/3D (padding/cropping), multi-item batches, ROI weight-map variants, documented padding aliases, and wrapper parity.

* **Documentation**
  * Updated the Utility guide to list the new inference helpers in the Sliding Window Inference section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->