### PR TITLE
Fix PyGrain multi-thread safe NormalizeIntensity

### DIFF
--- a/medicai/transforms/intensity/normalize_intensity.py
+++ b/medicai/transforms/intensity/normalize_intensity.py
@@ -4,6 +4,7 @@ import tensorflow as tf
 
 from ..base import KeyedTransform
 from ..tensor_bundle import TensorBundle
+from ..utils import custom_tf_boolean_mask
 
 
 class NormalizeIntensity(KeyedTransform):
@@ -134,7 +135,7 @@ class NormalizeIntensity(KeyedTransform):
 
         def normalize_single_channel(channel_and_mask):
             channel, channel_mask = channel_and_mask
-            channel_masked = tf.boolean_mask(channel, channel_mask)
+            channel_masked = custom_tf_boolean_mask(channel, channel_mask, mode="extract")
             has_valid = tf.size(channel_masked) > 0
 
             def normalize_nonempty():
@@ -172,7 +173,7 @@ class NormalizeIntensity(KeyedTransform):
         num_valid = tf.reduce_sum(tf.cast(mask, tf.int32))
 
         def normalize():
-            vals = tf.boolean_mask(tensor, mask)
+            vals = custom_tf_boolean_mask(tensor, mask, mode="extract")
             mean = tf.reduce_mean(vals)
             std = tf.math.reduce_std(vals)
             std = tf.where(std == 0.0, 1.0, std)

--- a/medicai/transforms/utils.py
+++ b/medicai/transforms/utils.py
@@ -4,6 +4,45 @@ from scipy import ndimage
 import tensorflow as tf
 
 
+def custom_tf_boolean_mask(
+    tensor: tf.Tensor,
+    mask: tf.Tensor,
+    mode: str = "extract",
+    fill_value=0,
+) -> tf.Tensor:
+    """Apply boolean-style masking using low-level TensorFlow ops.
+
+    This helper exists because ``tf.boolean_mask`` has shown nondeterministic
+    failures in some multi-threaded GPU data pipeline contexts. See TensorFlow
+    issue ``#123980`` for background.
+
+    Args:
+        tensor: Input tensor to mask.
+        mask: Boolean or numeric mask aligned with ``tensor``.
+        mode: Masking strategy. ``"extract"`` gathers only the selected
+            elements, ``"where"`` preserves the original shape and fills
+            masked-out entries with ``fill_value``, and ``"multiply"`` applies
+            elementwise masking after casting the mask to ``tensor.dtype``.
+        fill_value: Scalar fill value used only when ``mode="where"``.
+
+    Returns:
+        tf.Tensor: Masked tensor according to the requested mode.
+
+    Raises:
+        ValueError: If ``mode`` is unsupported.
+    """
+    bool_mask = tf.cast(mask, tf.bool) if mask.dtype != tf.bool else mask
+
+    if mode == "extract":
+        indices = tf.where(bool_mask)
+        return tf.gather_nd(tensor, indices)
+    if mode == "where":
+        return tf.where(bool_mask, tensor, tf.cast(fill_value, tensor.dtype))
+    if mode == "multiply":
+        return tf.multiply(tensor, tf.cast(mask, tensor.dtype))
+    raise ValueError(f"Unsupported mode '{mode}'. Choose from 'extract', 'where', or 'multiply'.")
+
+
 def largest_component_mask(mask: np.ndarray, closing_iterations: int = 2) -> np.ndarray:
     """Keep only the largest connected foreground component of a binary mask.
 


### PR DESCRIPTION
fix https://github.com/innat/medic-ai/issues/108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added flexible boolean masking support for tensor operations, including extraction, shape-preserving masking, and elementwise masking.

* **Bug Fixes**
  * Improved intensity normalization reliability by using the new masking behavior for both channel-wise and global normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->